### PR TITLE
Import PropTypes from the 'prop-types' module instead of from 'react'…

### DIFF
--- a/CircleTransition.js
+++ b/CircleTransition.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Easing, Modal, Dimensions, Animated } from 'react-native'
 const { width, height } = Dimensions.get('window')
 const reactMixin = require('react-mixin')


### PR DESCRIPTION
…. Note: Necessary for usage with React past version 16

When I tried using the module with the current version of React (16.2.0) I got `undefined is not an object (evaluating '_react2.PropTypes.string')`. This commit fixes the issue.